### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "urls": [
+    ["ina_ti.py", "github:octaprog7/INA_TI/ina_ti.py"],
+    ["main_ina219.py", "github:octaprog7/INA_TI/main_ina219.py"],
+    ["main_ina226.py", "github:octaprog7/INA_TI/main_ina226.py"],
+    ["sensor_pack_2/__init__.py", "github:octaprog7/INA_TI/sensor_pack_2/__init__.py"],
+    ["sensor_pack_2/adcmod.py", "github:octaprog7/INA_TI/sensor_pack_2/adcmod.py"],
+    ["sensor_pack_2/base_sensor.py", "github:octaprog7/INA_TI/sensor_pack_2/base_sensor.py"],
+    ["sensor_pack_2/bitfield.py", "github:octaprog7/INA_TI/sensor_pack_2/bitfield.py"],
+    ["sensor_pack_2/bus_service.py", "github:octaprog7/INA_TI/sensor_pack_2/bus_service.py"],
+    ["sensor_pack_2/regmod.py", "github:octaprog7/INA_TI/sensor_pack_2/regmod.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
## Summary
- Add package.json file to make this library installable via the MicroPython Package Manager (MIP)
- Enables installation with `mip install github:octaprog7/INA_TI`
- Includes all necessary files including sensor_pack_2 module dependencies

## Test plan
- Verify that the package can be installed using MIP

🤖 Generated with [Claude Code](https://claude.ai/code)